### PR TITLE
Update header menu order and fix anchor links

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -14,6 +14,19 @@ function Header() {
     setMenuOpen(false);
   };
 
+  const scrollToSection = (e, id) => {
+    e.preventDefault();
+    const element = document.getElementById(id);
+    if (element) {
+      // Optional: adjust offset if you have a sticky header
+      element.scrollIntoView({ behavior: 'smooth' });
+    } else {
+      // If not on the homepage, navigate to the homepage with hash
+      window.location.hash = `#${id}`;
+    }
+    setMenuOpen(false);
+  };
+
   return (
     <header className="header">
       <nav>
@@ -30,12 +43,12 @@ function Header() {
           </div>
         </div>
         <ul className={`nav-links ${menuOpen ? 'open' : ''}`}>
-          <li><a href="#about" onClick={() => setMenuOpen(false)}>About</a></li>
-          <li><a href="#journey" onClick={() => setMenuOpen(false)}>Journey</a></li>
-          <li><a href="#projects" onClick={() => setMenuOpen(false)}>Projects</a></li>
-          <li><a href="#research" onClick={() => setMenuOpen(false)}>Research</a></li>
+          <li><a href="#about" onClick={(e) => scrollToSection(e, 'about')}>About</a></li>
+          <li><a href="#journey" onClick={(e) => scrollToSection(e, 'journey')}>Journey</a></li>
+          <li><a href="#research" onClick={(e) => scrollToSection(e, 'research')}>Research</a></li>
+          <li><a href="#projects" onClick={(e) => scrollToSection(e, 'projects')}>Projects</a></li>
           <li><a href="https://drive.google.com/file/d/1yv1W7eKhy0TpWrzRbeUlMVBZvCY3nFib/view?usp=sharing" target="_blank" rel="noopener noreferrer">CV</a></li>
-          <li><a href="#contact" onClick={() => setMenuOpen(false)}>Contact</a></li>
+          <li><a href="#contact" onClick={(e) => scrollToSection(e, 'contact')}>Contact</a></li>
         </ul>
       </nav>
     </header>


### PR DESCRIPTION
This submission fixes two issues with the Header menu:
1. Reordered the items to match the main page content ("Research" and "Projects" swapped).
2. Changed the way links work to prevent them from failing or redirecting the user unexpectedly due to the HashRouter intercepting local anchor tags. Instead, a `scrollToSection` helper is used to call `scrollIntoView` natively.

---
*PR created automatically by Jules for task [3444447971720577009](https://jules.google.com/task/3444447971720577009) started by @ChristopheMuller*